### PR TITLE
FEAT:ChildDiaryPost: 아이 일기 작성 페이지 구현, 부모 작성 완료 버튼 수정 필요

### DIFF
--- a/Dasori/lib/screens/diary/child_diary_camera.dart
+++ b/Dasori/lib/screens/diary/child_diary_camera.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart'; // 날짜 형식을 사용하기 위한 패키지
 
 class Camera extends StatefulWidget {
   const Camera({Key? key}) : super(key: key);
@@ -63,7 +64,139 @@ class _CameraState extends State<Camera> {
       height: height * 0.55,
       child: Column(
           children: [
-          ]
+            SizedBox(height: height * 0.02),
+            Row(
+              children: [
+                SizedBox(width: width * 0.05),
+                Text(
+                    DateFormat('yyyy년 MM월 dd일 EEEE').format(DateTime.now()),
+                    textAlign: TextAlign.start,
+                    style: TextStyle(
+                      color: Color(0xff787B7D),
+                      fontSize: height * 0.02,
+                    )
+                ),
+              ],
+            ),
+            Row(
+                children: [
+                  SizedBox(width: width * 0.05),
+                  Text(
+                      "아이의 일기",
+                      textAlign: TextAlign.start,
+                      style: TextStyle(
+                        color: Color(0xff787B7D),
+                        fontSize: height * 0.03,
+                      )
+                  ),
+                ]
+            ),
+            Text(
+                "--------------------------- 촬영 가이드 ---------------------------",
+                textAlign: TextAlign.start,
+                style: TextStyle(
+                  color: Color(0xff787B7D),
+                  fontSize: height * 0.025,
+                )
+            ),
+            SizedBox(height: height * 0.002),
+            Row(
+              children: [
+                SizedBox(width: width * 0.15),
+                RichText(
+                  textAlign: TextAlign.start,
+                  text: TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '1. 글씨가 잘 보이도록 밝은 곳에서 촬영해주세요. \n',
+                        style: TextStyle(color: Color(0xff787B7D), fontSize: height * 0.02, ),
+                      ),
+                      TextSpan(
+                        text: 'Hãy quay ở nơi sáng để thấy rõ chữ nhé. \n',
+                        style: TextStyle(color: Color(0xff8DBFD2), fontSize: height * 0.02),
+                      ),
+                      TextSpan(
+                        text: '2. 아이 일기를 촬영 영역에 맞춰주세요.\n',
+                        style: TextStyle(color: Color(0xff787B7D), fontSize: height * 0.02),
+                      ),
+                      TextSpan(
+                        text: 'Hãy điều chỉnh nhật ký cho phù hợp với \nlĩnh vực ghi hình.\n',
+                        style: TextStyle(color: Color(0xff8DBFD2), fontSize: height * 0.02),
+                      ),
+                      TextSpan(
+                        text: '3. 표시된 빨간선이 그림과 글씨 사이에 위치하도록 \n맞추고 촬영해주세요. \n',
+                        style: TextStyle(color: Color(0xff787B7D), fontSize: height * 0.02),
+                      ),
+                      TextSpan(
+                        text: 'Hãy điều chỉnh và chụp sao cho đường màu đỏ \nđược hiển  thị nằm giữa hình ảnh và chữ viết. \n',
+                        style: TextStyle(color: Color(0xff8DBFD2), fontSize: height * 0.02),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            )
+
+          //   Column(
+          //     children: [
+          //       Row(
+          //           children: [
+          //             SizedBox(width: width * 0.15),
+          //             Text(
+          //                 "1. 글씨가 잘 보이도록 밝은 곳에서 촬영해주세요. \n",
+          //                 textAlign: TextAlign.start,
+          //                 style: TextStyle(
+          //                   color: Color(0xff787B7D),
+          //                   fontSize: height * 0.02,
+          //                 )
+          //             ),
+          //           ]
+          //       ),
+          //       Row(
+          //           children: [
+          //             SizedBox(width: width * 0.15),
+          //             Text(
+          //                 "Hãy quay ở nơi sáng để thấy rõ chữ nhé.\n",
+          //                 textAlign: TextAlign.start,
+          //                 style: TextStyle(
+          //                   color: Color(0xff8DBFD2),
+          //                   fontSize: height * 0.02,
+          //                 )
+          //             ),
+          //           ]
+          //       ),
+          //       Row(
+          //         crossAxisAlignment: CrossAxisAlignment.start,
+          //         children: [
+          //           SizedBox(width: width * 0.15),
+          //           Text(
+          //             "2. 아이 일기를 촬영 영역에 맞춰주세요. \n",
+          //             textAlign: TextAlign.start,
+          //             style: TextStyle(
+          //               color: Color(0xff787B7D),
+          //               fontSize: height * 0.02,
+          //             ),
+          //           ),
+          //         ],
+          //       ),
+          //       Row(
+          //         crossAxisAlignment: CrossAxisAlignment.start,
+          //         children: [
+          //           SizedBox(width: width * 0.15),
+          //           Text(
+          //             "Hãy điều chỉnh nhật ký cho phù hợp \nvới lĩnh vực ghi hình.",
+          //             textAlign: TextAlign.start,
+          //             style: TextStyle(
+          //               color: Color(0xff8DBFD2),
+          //               fontSize: height * 0.02,
+          //             ),
+          //           ),
+          //         ],
+          //       ),
+          //     ],
+          //   )
+          // ]
+        ],
       ),
     );
   }

--- a/Dasori/lib/screens/diary/parent_diary_upload.dart
+++ b/Dasori/lib/screens/diary/parent_diary_upload.dart
@@ -64,6 +64,7 @@ class _UploadState extends State<Upload> {
       height: height * 0.55,
       child: Column(
         children: [
+          SizedBox(height: height * 0.02),
           Row(
             children: [
               SizedBox(width: width * 0.05),
@@ -114,7 +115,7 @@ class _UploadState extends State<Upload> {
           decoration: InputDecoration(
             fillColor: Colors.white,
             filled: true,
-            hintText: "오늘의 일기를 작성하세요. \n Hãy viết nhật ký hôm nay.",
+            hintText: "오늘의 일기를 작성하세요. \nHãy viết nhật ký hôm nay.",
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(width * 0.05),
               ),
@@ -129,12 +130,34 @@ class _UploadState extends State<Upload> {
     final height = MediaQuery.of(context).size.height;
 
     return Container(
-      height: height * 0.02,
-        margin: EdgeInsets.all(5),
-        child: Center(
-          child: Text('작성 완료'),
+      width: width * 0.8,
+      height: height * 0.08,
+      margin: EdgeInsets.all(5),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.white),
+        borderRadius: BorderRadius.circular(60.0),
+      ),
+      child: TextButton(
+        onPressed: () {
+          // 여기에 부모 일기 작성하는 통신 추가
+          // URL: /home/parent
+        },
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Text(
+              '작성 완료',
+              style: TextStyle(color: Colors.white, fontSize: height * 0.03),
+            ),
+            SizedBox(width: 0),
+            Text(
+              'Hoàn thành việc',
+              style: TextStyle(color: Colors.white, fontSize: height * 0.02),
+            ),
+          ],
         ),
-      );
+      ),
+    );
   }
 
   @override

--- a/Dasori/lib/widgets/navigation_bar.dart
+++ b/Dasori/lib/widgets/navigation_bar.dart
@@ -23,8 +23,10 @@ class _NavBarState extends State<NavBar> {
             children: <Widget>[
               Home(),
               Conversation(),
-              Container(child: Center(child: Text('report'),),),
-              Container(child: Center(child: Text('setting'),),)
+              // Container(child: Center(child: Text('report'),),),
+              // Container(child: Center(child: Text('setting'),),)
+              Upload(),
+              Camera()
             ],
           ),
 
@@ -52,7 +54,7 @@ class _NavBarState extends State<NavBar> {
                           Navigator.push(
                             context,
                             // MaterialPageRoute(builder: (context) => Upload()),
-                            MaterialPageRoute(builder: (context) => Camera()),
+                            MaterialPageRoute(builder: (context) => Upload()),
                           );
                         },
                       ),


### PR DESCRIPTION
FEAT:ChildDiaryPost: 아이 일기 작성 페이지 구현, 부모 작성 완료 버튼 수정 필요

일단 아이 일기 작성 페이지까지는 구현이 끝나긴했는데, 아이 '작성 완료' 버튼 및 부모 '작성 완료' 버튼 추가 해야합니다.
금일 이내로 작성된 일기 교정본 및 번역본 띄우는 페이지 완료하고, 아이 카메라 손봐보도록 하겠습니다.